### PR TITLE
Updated the xpath for the go to web button.

### DIFF
--- a/alright/__init__.py
+++ b/alright/__init__.py
@@ -120,7 +120,7 @@ class WhatsApp(object):
             time.sleep(2)
             go_to_web = self.wait.until(
                 EC.presence_of_element_located(
-                    (By.XPATH, '//*[@id="fallback_block"]/div/div/a')
+                    (By.XPATH, '//*[@id="fallback_block"]/div/div/h4[2]/a')
                 )
             )
             go_to_web.click()


### PR DESCRIPTION
Just changed the xpath for the "go to web" button to make it work, since whatsapp added a h4 element that prevented it from working.

Before: 
` "//*[@id="fallback_block"]/div/div/a" to`

After: 
`"//*[@id="fallback_block"]/div/div/h4[2]/a"`

P.D: this is my first contribution ever so if i messed up let me know.