### PR TITLE
Updating the XPATH on find_by_username method

### DIFF
--- a/alright/__init__.py
+++ b/alright/__init__.py
@@ -78,6 +78,13 @@ class WhatsApp(object):
         )
         logout_item.click()
 
+    def close_browser(self):
+        """close_browser()
+
+        closes the browser window to allow repeated calls
+        """
+        self.browser.close()
+
     def get_phone_link(self, mobile) -> str:
         """get_phone_link (), create a link based on whatsapp (wa.me) api
 
@@ -141,7 +148,7 @@ class WhatsApp(object):
         try:
             search_box = self.wait.until(
                 EC.presence_of_element_located(
-                    (By.XPATH, '//*[@id="side"]/div[1]/div/label/div/div[2]')
+                    (By.XPATH, '//*[@id="app"]/div[1]/div[1]/div[3]/div[1]/div[1]/div[1]/div[1]/div[2]/div[1]/div[2]')
                 )
             )
             search_box.clear()


### PR DESCRIPTION
As per issue #56, when trying to send a simple message, the execution hang forever and nothing happened. While debugging, it was noticed that the XPATH for the `search_box` on _find_by_username_ was not correct, probably due to an app update. 

So, currently, this is incorrect:

```
            search_box = self.wait.until(
                EC.presence_of_element_located(
                    (By.XPATH, '//*[@id="side"]/div[1]/div/label/div/div[2]')
                )
            )
```

And this is correct:

```
            search_box = self.wait.until(
                EC.presence_of_element_located(
                    (By.XPATH, '//*[@id="app"]/div[1]/div[1]/div[3]/div[1]/div[1]/div[1]/div[1]/div[2]/div[1]/div[2]')
                )
            )
```

In addition, seizing the PR, it is delivered a method for closing the browser after sending a message - it is advised, though, to drop a sleep after sending an image/video and before calling the method to close the browser, otherwise the message content will not be delivered correctly.

Since unit testing is not the procedure adopted on this repo, [this](https://github.com/euriconicacio/stuff/blob/main/gg_message/whatsapp_msg.py) code works perfectly with the up-mentioned change in the XPATH.