### PR TITLE
Fixes for firefox

### DIFF
--- a/alright/__init__.py
+++ b/alright/__init__.py
@@ -20,7 +20,6 @@ from selenium.common.exceptions import (
     UnexpectedAlertPresentException,
     NoSuchElementException,
 )
-from webdriver_manager.chrome import ChromeDriverManager
 from urllib.parse import quote
 
 LOGGER = logging.getLogger()
@@ -35,6 +34,8 @@ class WhatsApp(object):
         self.suffix_link = "https://web.whatsapp.com/send?phone={mobile}&text&type=phone_number&app_absent=1"
 
         if not browser:
+            from webdriver_manager.chrome import ChromeDriverManager
+
             browser = webdriver.Chrome(
                 ChromeDriverManager().install(),
                 options=self.chrome_options,

--- a/alright/__init__.py
+++ b/alright/__init__.py
@@ -469,10 +469,11 @@ class WhatsApp(object):
                 EC.presence_of_element_located((By.XPATH, inp_xpath))
             )
             for line in message.split("\n"):
-                input_box.send_keys(line)
-                ActionChains(self.browser).key_down(Keys.SHIFT).key_down(
-                    Keys.ENTER
-                ).key_up(Keys.ENTER).key_up(Keys.SHIFT).perform()
+                ActionChains(self.browser).send_keys_to_element(
+                    input_box, line
+                ).key_down(Keys.SHIFT).key_down(Keys.ENTER).key_up(Keys.ENTER).key_up(
+                    Keys.SHIFT
+                ).perform()
             input_box.send_keys(Keys.ENTER)
             LOGGER.info(f"Message sent successfuly to {self.mobile}")
         except (NoSuchElementException, Exception) as bug:


### PR DESCRIPTION
I'm using firefox and don't have the chrome driver installed. This throws a ModuleNotFound error at this line
```python
from webdriver_manager.chrome import ChromeDriverManager
```
I've fixed it by only having this line execute when a custom driver is not provided.


Also, when doing `messenger.send_message` on Firefox, only 1 character was being sent. Resolved this by chaining the send_keys and Shift+Enter operations.