### PR TITLE
switch to platformdirs. Closes: #104

### DIFF
--- a/alright/__init__.py
+++ b/alright/__init__.py
@@ -8,6 +8,7 @@ import os
 import sys
 import time
 import logging
+import platformdirs
 from selenium import webdriver
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
@@ -55,12 +56,11 @@ class WhatsApp(object):
     @property
     def chrome_options(self):
         chrome_options = Options()
+        chrome_options.add_argument("--user-data-dir=" + platformdirs.user_data_dir("alright"))
         if sys.platform == "win32":
             chrome_options.add_argument("--profile-directory=Default")
-            chrome_options.add_argument("--user-data-dir=C:/Temp/ChromeProfile")
         else:
             chrome_options.add_argument("start-maximized")
-            chrome_options.add_argument("--user-data-dir=./User_Data")
         return chrome_options
 
     def cli(self):

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "python-whatsapp-wrapper",
     ],
     install_requires=[
+        "platformdirs",
         "selenium",
         "webdriver-manager",
     ],


### PR DESCRIPTION
- add platformdirs python library to runtime dependencies
- use platformdirs' magic to determine where to store user data