### PR TITLE
New feature link preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ Here how to send a message to multiple users, Let's say we want to wish merry-x 
 
 *You have to include the **country code** in your number for this library to work but don't include the (+) symbol*
 
+### Sending Links (Link Preview)
+
+Sending messages with a link and link preview can be accomplished by setting the `wait_for_link_preview` flag in the **send_message** or **send_direct_message** function to `True` 
+
+```python
+>>> from alright import WhatsApp
+>>> messenger = WhatsApp()
+>>> messenger.send_direct_message('25573652xxx', 'https://github.com/Kalebu/alright', True, True)
+```
+
 ### Sending Images
 
 Sending Images is nothing new, its just the fact you have to include a path to your image and the message to accompany the image instead of just the raw string characters and also you have use *send_picture()*, Here an example;

--- a/alright/__init__.py
+++ b/alright/__init__.py
@@ -487,6 +487,27 @@ class WhatsApp(object):
             self.find_user(mobile)
         self.send_message(message)
 
+    def wait_for_link_preview(self, timeout = 30):
+        """Wait until the link preview is created.
+
+        Args:
+            timeout (int, optional): Max time to wait in seconds. Defaults to 30.
+        """
+        link_preview_xpath = (
+                '//*[@id="main"]/div[3]'
+            )
+        link_preview_element = self.wait.until(
+                EC.presence_of_element_located((By.XPATH, link_preview_xpath))
+            )
+        def extract_height(element):
+            return int(element.get_attribute("style").split("height:")[1].split("px")[0])
+        time_counter_s = 0
+        thumbnail_height = extract_height(link_preview_element)
+        while ( thumbnail_height == 0 and time_counter_s < timeout):
+            time.sleep(1)
+            thumbnail_height = extract_height(link_preview_element)
+            time_counter_s +=1
+
     def find_attachment(self):
         clipButton = self.wait.until(
             EC.presence_of_element_located(

--- a/alright/__init__.py
+++ b/alright/__init__.py
@@ -455,12 +455,13 @@ class WhatsApp(object):
             LOGGER.info(f"{msg}")
             return msg
 
-    def send_message(self, message):
+    def send_message(self, message, wait_for_link_preview=False):
         """send_message ()
         Sends a message to a target user
 
         Args:
             message ([type]): [description]
+            wait_for_link_preview (bool): Wait until the link preview is shown. Defaults to False.
         """
         try:
             inp_xpath = (
@@ -474,18 +475,20 @@ class WhatsApp(object):
                 ActionChains(self.browser).key_down(Keys.SHIFT).key_down(
                     Keys.ENTER
                 ).key_up(Keys.ENTER).key_up(Keys.SHIFT).perform()
+            if wait_for_link_preview:
+                self.wait_for_link_preview()
             input_box.send_keys(Keys.ENTER)
             LOGGER.info(f"Message sent successfuly to {self.mobile}")
         except (NoSuchElementException, Exception) as bug:
             LOGGER.exception(f"Failed to send a message to {self.mobile} - {bug}")
             LOGGER.info("send_message() finished running!")
 
-    def send_direct_message(self, mobile: str, message: str, saved: bool = True):
+    def send_direct_message(self, mobile: str, message: str, saved: bool = True, wait_for_link_preview: bool = False):
         if saved:
             self.find_by_username(mobile)
         else:
             self.find_user(mobile)
-        self.send_message(message)
+        self.send_message(message, wait_for_link_preview)
 
     def wait_for_link_preview(self, timeout = 30):
         """Wait until the link preview is created.


### PR DESCRIPTION
# Overview

Added feature to wait for a Link Preview.

Successfully tested with Chrome Browser and Chrome-Driver 110.0.5481.77
Not tested with anything else.

Related to Issue #25 

# Implementation

- A link preview appears above the text input if a link is part of the message.
- A function was added which waits until the height of the preview is bigger than 0.
  - Height is polled every second until it is bigger than 0 or a timeout occurs. 
- After a timeout the message is sent even if no preview appears.
- Waiting for this preview is disabled by default and can be enabled with a flag in`send_message` and  `send_direct_message`