### PR TITLE
option to create headless chrome

### DIFF
--- a/alright/__init__.py
+++ b/alright/__init__.py
@@ -27,13 +27,13 @@ LOGGER = logging.getLogger()
 
 
 class WhatsApp(object):
-    def __init__(self, browser=None, time_out=600):
+    def __init__(self, headless=False, browser=None, time_out=600):
         # CJM - 20220419: Added time_out=600 to allow the call with less than 600 sec timeout
         # web.open(f"https://web.whatsapp.com/send?phone={phone_no}&text={quote(message)}")
 
         self.BASE_URL = "https://web.whatsapp.com/"
         self.suffix_link = "https://web.whatsapp.com/send?phone={mobile}&text&type=phone_number&app_absent=1"
-
+        self.headless= headless
         if not browser:
             browser = webdriver.Chrome(
                 ChromeDriverManager().install(),
@@ -56,6 +56,7 @@ class WhatsApp(object):
     @property
     def chrome_options(self):
         chrome_options = Options()
+        chrome_options.headless = self.headless
         chrome_options.add_argument(
             "--user-data-dir=" + platformdirs.user_data_dir("alright")
         )


### PR DESCRIPTION
This pull request adds a new option to enable headless mode in Chrome for the alright library. The new option is called headless and can be set to True or False.

To implement this feature, I updated the WhatsApp class to accept a new headless argument in the __init__ method. If the headless argument is set to True, the --headless argument is added to the Chrome options.

Overall, this feature should provide a more flexible and customizable experience for users of the alright library who want to run Chrome in headless mode.