### PR TITLE
fix TypeError: WebDriver.__init__() got multiple values for argument …

### DIFF
--- a/alright/__init__.py
+++ b/alright/__init__.py
@@ -15,6 +15,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
@@ -37,8 +38,8 @@ class WhatsApp(object):
 
         if not browser:
             browser = webdriver.Chrome(
-                ChromeDriverManager().install(),
                 options=self.chrome_options,
+                service=Service(ChromeDriverManager().install())
             )
 
             handles = browser.window_handles


### PR DESCRIPTION
…'options'

The issue is being caused due to changes in Selenium (4.10.0).
Now, to pass in an executable path, it requires the use of the service arg.