### PR TITLE
Fixes Issue #142

### DIFF
--- a/alright/__init__.py
+++ b/alright/__init__.py
@@ -23,6 +23,7 @@ from selenium.common.exceptions import (
     NoSuchElementException,
 )
 from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.chrome.service import Service
 
 LOGGER = logging.getLogger()
 
@@ -37,7 +38,7 @@ class WhatsApp(object):
 
         if not browser:
             browser = webdriver.Chrome(
-                ChromeDriverManager().install(),
+                service=Service(executable_path=ChromeDriverManager().install()),
                 options=self.chrome_options,
             )
 


### PR DESCRIPTION
This change is due to Selenium 4.10.0. the first argument is no longer executable_path, but options. (That's why it complains that you're passing it in twice.)

If you want to pass in an executable_path, you'll have to use the service arg now.